### PR TITLE
Part2 of exception handling support 

### DIFF
--- a/core/iwasm/interpreter/wasm.h
+++ b/core/iwasm/interpreter/wasm.h
@@ -14,13 +14,6 @@
 extern "C" {
 #endif
 
-#if WASM_ENABLE_EXCE_HANDLING != 0
-#define _EXCEWARNING \
-    LOG_WARNING /* for exception handling misbehavior logging */
-#define _EXCEVERBOSE \
-    LOG_VERBOSE /* more excessive tracing of tagbrowsing and stack pointers */
-#endif
-
 /** Value Type */
 #define VALUE_TYPE_I32 0x7F
 #define VALUE_TYPE_I64 0X7E
@@ -223,15 +216,18 @@ typedef struct WASMFunctionImport {
 
 #if WASM_ENABLE_TAGS != 0
 typedef struct WASMTagImport {
+    char *module_name;
+    char *field_name;
     uint8 attribute; /* the type of the tag (numerical) */
     uint32 type;     /* the type of the catch function (numerical)*/
     WASMType *tag_type;
-    uint32 tag_index_linked;
+    void *tag_ptr_linked;
+
 #if WASM_ENABLE_MULTI_MODULE != 0
-    /* imported function pointer after linked */
-    /* TODO: remove if not needed */
+    /* imported tag  pointer after linked */
     WASMModule *import_module;
     WASMTag *import_tag_linked;
+    uint32 import_tag_index_linked;
 #endif
 } WASMTagImport;
 #endif
@@ -340,6 +336,7 @@ struct WASMFunction {
 struct WASMTag {
     uint8 attribute; /* the attribute property of the tag (expected to be 0) */
     uint32 type; /* the type of the tag (expected valid inden in type table) */
+    WASMType *tag_type;
 };
 #endif
 
@@ -505,7 +502,7 @@ struct WASMModule {
     WASMTable *tables;
     WASMMemory *memories;
 #if WASM_ENABLE_TAGS != 0
-    WASMTag *tags;
+    WASMTag **tags;
 #endif
     WASMGlobal *globals;
     WASMExport *exports;

--- a/core/iwasm/interpreter/wasm_interp_classic.c
+++ b/core/iwasm/interpreter/wasm_interp_classic.c
@@ -1278,7 +1278,7 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
 
                 /* get tag type */
                 uint8 tag_type_index =
-                    module->module->tags[exception_tag_index].type;
+                    module->module->tags[exception_tag_index]->type;
                 uint32 cell_num_to_copy =
                     wasm_types[tag_type_index]->param_cell_num;
 
@@ -1297,9 +1297,35 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
             {
                 read_leb_int32(frame_ip, frame_ip_end, exception_tag_index);
 
-            /* landig pad for the rethrow ? */
+            /* landing pad for the rethrow ? */
             find_a_catch_handler:
             {
+                WASMType *tag_type = NULL;
+                uint32 cell_num_to_copy = 0;
+                if (IS_INVALID_TAGINDEX(exception_tag_index)) {
+                    /*
+                     * invalid exception index,
+                     * generated if a submodule throws an exception
+                     * that has not been imported here
+                     *
+                     * This should result in a branch to the CATCH_ALL block,
+                     * if there is one
+                     */
+                    tag_type = NULL;
+                    cell_num_to_copy = 0;
+                }
+                else {
+                    if (module->tags[exception_tag_index].is_import_tag) {
+                        tag_type = module->tags[exception_tag_index]
+                                       .u.tag_import->tag_type;
+                    }
+                    else {
+                        tag_type =
+                            module->tags[exception_tag_index].u.tag->tag_type;
+                    }
+                    cell_num_to_copy = tag_type->param_cell_num;
+                }
+
                 /* browse through frame stack */
                 uint32 relative_depth = 0;
                 do {
@@ -1315,7 +1341,8 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             /*
                              * skip that blocks in search
                              * BLOCK, IF and LOOP do not contain handlers and
-                             * cannot catch exceptions blocks marked as CATCH or
+                             * cannot catch exceptions.
+                             * blocks marked as CATCH or
                              * CATCH_ALL did already caugth an exception and can
                              * only be a target for RETHROW, but cannot catch an
                              * exception again
@@ -1353,34 +1380,20 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                                             UNWIND_CSP(relative_depth,
                                                        LABEL_TYPE_CATCH);
 
-                                            /* transfer exception values */
-                                            uint8 tag_type_index =
-                                                module->module
-                                                    ->tags[exception_tag_index]
-                                                    .type;
-                                            uint32 cell_num_to_copy =
-                                                wasm_types[tag_type_index]
-                                                    ->param_cell_num;
                                             /* push exception_tag_index and
                                              * exception values for rethrow */
                                             PUSH_I32(exception_tag_index);
-                                            if (cell_num_to_copy > 0) {
-                                                word_copy(
-                                                    frame_sp,
-                                                    frame_sp_old
-                                                        - cell_num_to_copy,
-                                                    cell_num_to_copy);
-                                            }
+                                            word_copy(frame_sp,
+                                                      frame_sp_old
+                                                          - cell_num_to_copy,
+                                                      cell_num_to_copy);
                                             frame_sp += cell_num_to_copy;
                                             /* push exception values for catch
                                              */
-                                            if (cell_num_to_copy > 0) {
-                                                word_copy(
-                                                    frame_sp,
-                                                    frame_sp_old
-                                                        - cell_num_to_copy,
-                                                    cell_num_to_copy);
-                                            }
+                                            word_copy(frame_sp,
+                                                      frame_sp_old
+                                                          - cell_num_to_copy,
+                                                      cell_num_to_copy);
                                             frame_sp += cell_num_to_copy;
 
                                             /* advance to handler */
@@ -1409,21 +1422,11 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                                         /* unwind to delegated frame */
                                         frame_csp -= lookup_depth;
 
-                                        /* transfer exception values */
-                                        uint8 tag_type_index =
-                                            module->module
-                                                ->tags[exception_tag_index]
-                                                .type;
-                                        uint32 cell_num_to_copy =
-                                            wasm_types[tag_type_index]
-                                                ->param_cell_num;
                                         /* push exception values for catch */
-                                        if (cell_num_to_copy > 0) {
-                                            word_copy(frame_sp,
-                                                      frame_sp_old
-                                                          - cell_num_to_copy,
-                                                      cell_num_to_copy);
-                                        }
+                                        word_copy(frame_sp,
+                                                  frame_sp_old
+                                                      - cell_num_to_copy,
+                                                  cell_num_to_copy);
                                         frame_sp += cell_num_to_copy;
 
                                         /* tag_index is already stored in
@@ -1445,25 +1448,11 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                                         /* push exception_tag_index and
                                          * exception values for rethrow */
                                         PUSH_I32(exception_tag_index);
-                                        if (exception_tag_index
-                                            != (int32_t)0xFFFFFFFF) {
-                                            /* transfer exception values */
-                                            uint8 tag_type_index =
-                                                module->module
-                                                    ->tags[exception_tag_index]
-                                                    .type;
-                                            uint32 cell_num_to_copy =
-                                                wasm_types[tag_type_index]
-                                                    ->param_cell_num;
-                                            if (cell_num_to_copy > 0) {
-                                                word_copy(
-                                                    frame_sp,
-                                                    frame_sp_old
-                                                        - cell_num_to_copy,
-                                                    cell_num_to_copy);
-                                            }
-                                            frame_sp += cell_num_to_copy;
-                                        }
+                                        word_copy(frame_sp,
+                                                  frame_sp_old
+                                                      - cell_num_to_copy,
+                                                  cell_num_to_copy);
+                                        frame_sp += cell_num_to_copy;
                                         /* catch_all has no exception values */
 
                                         /* advance to handler */
@@ -1475,7 +1464,6 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                                                     "unexpected handler type");
                                         goto got_exception;
                                 }
-
                                 handler_number++;
                             }
                             /* exception not catched in this frame */
@@ -1487,29 +1475,16 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                             uint32 *frame_sp_old = frame_sp;
 
                             UNWIND_CSP(relative_depth, LABEL_TYPE_FUNCTION);
-                            if (exception_tag_index
-                                >= (int32_t)module->module->tag_count) {
-                                wasm_set_exception(module, "invalid tag index");
-                                goto got_exception;
-                            }
-
-                            /* transfer exception values */
-                            uint8 tag_type_index =
-                                module->module->tags[exception_tag_index].type;
-                            uint32 cell_num_to_copy =
-                                wasm_types[tag_type_index]->param_cell_num;
                             /* push exception values for catch
                              * The values are copied to the CALLER FRAME
                              * (prev_frame->sp) same behvior ad WASM_OP_RETURN
                              */
-                            if (cell_num_to_copy > 0) {
-                                word_copy(prev_frame->sp,
-                                          frame_sp_old - cell_num_to_copy,
-                                          cell_num_to_copy);
-                            }
+                            word_copy(prev_frame->sp,
+                                      frame_sp_old - cell_num_to_copy,
+                                      cell_num_to_copy);
                             prev_frame->sp += cell_num_to_copy;
                             *((int32 *)(prev_frame->sp)) = exception_tag_index;
-                            (int32 *)(prev_frame->sp++);
+                            prev_frame->sp++;
 
                             /* mark frame as raised exception */
                             wasm_set_exception(module,
@@ -4318,37 +4293,37 @@ wasm_interp_call_func_bytecode(WASMModuleInstance *module,
                     /* fix framesp */
                     UPDATE_ALL_FROM_FRAME();
 
-                    uint32 import_exception =
-                        0xFFFFFFFF; /* initialize imported exception index to be
-                                       invalid */
+                    uint32 import_exception;
+                    /* initialize imported exception index to be invalid */
+                    SET_INVALID_TAGINDEX(import_exception);
+
                     /* pull external exception */
                     uint32 ext_exception = POP_I32();
 
-                    WASMModule *im_mod = cur_func->u.func_import->import_module;
-
                     /* external function came back with an exception or trap */
                     /* lookup exception in import tags */
-                    uint32 import_tag_index;
-                    for (import_tag_index = 0;
-                         import_tag_index < module->module->import_tag_count;
-                         import_tag_index++) {
-                        WASMTagImport *im_tag =
-                            &(module->module->import_tags[import_tag_index]
-                                  .u.tag);
+                    WASMTagInstance *tag = module->tags;
+                    for (uint32 t = 0; t < module->module->import_tag_count;
+                         tag++, t++) {
 
                         /* compare the module and the external index with the
                          * imort tag data */
-                        if ((im_mod == im_tag->import_module)
-                            && (ext_exception == im_tag->tag_index_linked)) {
+                        if ((cur_func->u.func_import->import_module
+                             == tag->u.tag_import->import_module)
+                            && (ext_exception
+                                == tag->u.tag_import
+                                       ->import_tag_index_linked)) {
                             /* set the import_exception to the import tag */
-                            import_exception = import_tag_index;
+                            import_exception = t;
                             break;
                         }
                     }
                     /*
-                     * push the internal exception index to stack,
-                     * or 0xffffffff in case, the external exception
-                     * is not in the import list
+                     * excange the thrown exception (index valid in submodule)
+                     * with the imported exception index (valid in this module)
+                     * if the module did not import the exception,
+                     * that results in a "INVALID_TAGINDEX", that triggers
+                     * an CATCH_ALL block, if there is one.
                      */
                     PUSH_I32(import_exception);
                 }

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -912,6 +912,59 @@ wasm_loader_resolve_global(const char *module_name, const char *global_name,
     return global;
 }
 
+#if WASM_ENABLE_TAGS != 0
+static WASMTag *
+wasm_loader_resolve_tag(const char *module_name, const char *tag_name,
+                        const WASMType *expected_tag_type,
+                        uint32 *linked_tag_index, char *error_buf,
+                        uint32 error_buf_size)
+{
+    WASMModuleCommon *module_reg;
+    WASMTag *tag = NULL;
+    WASMExport *export = NULL;
+    WASMModule *module = NULL;
+
+    module_reg = wasm_runtime_find_module_registered(module_name);
+    if (!module_reg || module_reg->module_type != Wasm_Module_Bytecode) {
+        LOG_DEBUG("can not find a module named %s for tag %s", module_name,
+                  tag_name);
+        set_error_buf(error_buf, error_buf_size, "unknown import");
+        return NULL;
+    }
+
+    module = (WASMModule *)module_reg;
+    export =
+        wasm_loader_find_export(module, module_name, tag_name, EXPORT_KIND_TAG,
+                                error_buf, error_buf_size);
+    if (!export) {
+        return NULL;
+    }
+
+    /* resolve tag type and tag */
+    if (export->index < module->import_tag_count) {
+        /* importing an imported tag from the submodule */
+        tag = module->import_tags[export->index].u.tag.import_tag_linked;
+    }
+    else {
+        /* importing an section tag from the submodule */
+        tag = module->tags[export->index - module->import_tag_count];
+    }
+
+    /* check function type */
+    if (!wasm_type_equal(expected_tag_type, tag->tag_type)) {
+        LOG_DEBUG("%s.%s failed the type check", module_name, tag_name);
+        set_error_buf(error_buf, error_buf_size, "incompatible import type");
+        return NULL;
+    }
+
+    if (linked_tag_index != NULL) {
+        *linked_tag_index = export->index;
+    }
+
+    return tag;
+}
+#endif
+
 static WASMModule *
 search_sub_module(const WASMModule *parent_module, const char *sub_module_name)
 {
@@ -1394,8 +1447,39 @@ load_tag_import(const uint8 **p_buf, const uint8 *buf_end,
                 WASMTagImport *tag, /* structure to fill */
                 char *error_buf, uint32 error_buf_size)
 {
-    WASMExport *export = 0;
+    /* attribute and type of the import statement */
+    uint8 declare_tag_attribute;
+    uint32 declare_type_index;
+    const uint8 *p = *p_buf, *p_end = buf_end;
+#if WASM_ENABLE_MULTI_MODULE != 0
     WASMModule *sub_module = NULL;
+#endif
+
+    /* get the one byte attribute */
+    CHECK_BUF(p, p_end, 1);
+    declare_tag_attribute = read_uint8(p);
+    if (declare_tag_attribute != 0) {
+        set_error_buf(error_buf, error_buf_size, "unknown tag attribute");
+        goto fail;
+    }
+
+    /* get type */
+    read_leb_uint32(p, p_end, declare_type_index);
+    /* compare against module->types */
+    if (declare_type_index >= parent_module->type_count) {
+        set_error_buf(error_buf, error_buf_size, "unknown tag type");
+        goto fail;
+    }
+
+    WASMType *declare_tag_type = parent_module->types[declare_type_index];
+
+    /* check, that the type of the declared tag returns void */
+    if (declare_tag_type->result_count != 0) {
+        set_error_buf(error_buf, error_buf_size,
+                      "tag type signature does not return void");
+
+        goto fail;
+    }
 
 #if WASM_ENABLE_MULTI_MODULE != 0
     if (!wasm_runtime_is_built_in_module(sub_module_name)) {
@@ -1405,75 +1489,37 @@ load_tag_import(const uint8 **p_buf, const uint8 *buf_end,
             return false;
         }
     }
+    /* wasm_loader_resolve_tag checks, that the imported tag
+     * and the declared tag have the same type
+     */
+    uint32 linked_tag_index = 0;
+    WASMTag *linked_tag = wasm_loader_resolve_tag(
+        sub_module_name, tag_name, declare_tag_type,
+        &linked_tag_index /* out */, error_buf, error_buf_size);
+    if (!linked_tag) {
+        return false;
+    }
 #endif
-
-    WASMModuleCommon *module_reg =
-        wasm_runtime_find_module_registered(sub_module_name);
-    if (!module_reg) {
-        set_error_buf(error_buf, error_buf_size,
-                      "load_tag_import: registered module not found");
-        goto fail;
-    }
-    sub_module = (WASMModule *)module_reg;
-    uint32 i;
-
-    export = sub_module->exports;
-    for (i = 0; i < sub_module->export_count; i++, export ++) {
-
-        if (export->kind == EXPORT_KIND_TAG
-            && strcmp(export->name, tag_name) == 0) {
-            WASMTag *imp_tag = (WASMTag *)&sub_module->tags[export->index];
-            WASMType *imp_tag_type =
-                (WASMType *)sub_module->types[imp_tag->type];
-            /* fill import tag*/
-            tag->tag_index_linked = export->index;
-            tag->tag_type = (WASMType *)sub_module->types[imp_tag->type];
-#if WASM_ENABLE_MULTI_MODULE != 0
-            tag->import_module = (WASMModule *)module_reg;
-            tag->import_tag_linked = &sub_module->tags[export->index];
-#endif
-        }
-    }
-
-    uint8 tag_attribute;
-    uint32 tag_type;
-    const uint8 *p = *p_buf, *p_end = buf_end;
-
-    /* get the one byte attribute */
-    CHECK_BUF(p, p_end, 1);
-    tag_attribute = read_uint8(p);
-    if (tag_attribute != 0) {
-        set_error_buf(error_buf, error_buf_size, "unknown tag attribute");
-        goto fail;
-    }
-
-    /* get type */
-    read_leb_uint32(p, p_end, tag_type);
-    /* compare against module->types */
-    if (tag_type >= parent_module->type_count) {
-        set_error_buf(error_buf, error_buf_size, "unknown tag type");
-        goto fail;
-    }
-
-    /* check, that the type of the referred tag returns void */
-    WASMType *func_type = (WASMType *)parent_module->types[tag_type];
-    if (func_type->result_count != 0) {
-        set_error_buf(error_buf, error_buf_size,
-                      "tag type signature does not return void");
-
-        goto fail;
-    }
-
     /* store to module tag declarations */
-    tag->attribute = tag_attribute;
-    tag->type = tag_type;
+    tag->attribute = declare_tag_attribute;
+    tag->type = declare_type_index;
+
+    tag->module_name = (char *)sub_module_name;
+    tag->field_name = (char *)tag_name;
+    tag->tag_type = declare_tag_type;
+    /* func_ptr_linked is for native registered symbol */
+#if WASM_ENABLE_MULTI_MODULE != 0
+    tag->import_module = sub_module;
+    tag->import_tag_linked = linked_tag;
+    tag->import_tag_index_linked = linked_tag_index;
+#endif
 
     *p_buf = p;
     (void)parent_module;
 
     LOG_VERBOSE("Load tag import success\n");
-    return true;
 
+    return true;
 fail:
     return false;
 }
@@ -2829,28 +2875,30 @@ load_tag_section(const uint8 *buf, const uint8 *buf_end, const uint8 *buf_code,
                  const uint8 *buf_code_end, WASMModule *module, char *error_buf,
                  uint32 error_buf_size)
 {
-    LOG_VERBOSE("In %s\n", __FUNCTION__);
+    (void)buf_code;
+    (void)buf_code_end;
+
     const uint8 *p = buf, *p_end = buf_end;
     size_t total_size = 0;
     /* number of tags defined in the section */
     uint32 section_tag_count = 0;
     uint8 tag_attribute;
     uint32 tag_type;
+    WASMTag *tag = NULL;
 
     /* get tag count */
     read_leb_uint32(p, p_end, section_tag_count);
-    module->tag_count = module->import_tag_count + section_tag_count;
+    module->tag_count = section_tag_count;
 
     if (section_tag_count) {
-        total_size = sizeof(WASMTag) * module->tag_count;
+        total_size = sizeof(WASMTag *) * module->tag_count;
         if (!(module->tags =
                   loader_malloc(total_size, error_buf, error_buf_size))) {
             return false;
         }
         /* load each tag, imported tags precede the tags */
         uint32 tag_index;
-        for (tag_index = module->import_tag_count;
-             tag_index < module->tag_count; tag_index++) {
+        for (tag_index = 0; tag_index < section_tag_count; tag_index++) {
 
             /* get the one byte attribute */
             CHECK_BUF(p, p_end, 1);
@@ -2874,9 +2922,15 @@ load_tag_section(const uint8 *buf, const uint8 *buf_end, const uint8 *buf_code,
                 goto fail;
             }
 
+            if (!(tag = module->tags[tag_index] = loader_malloc(
+                      sizeof(WASMTag), error_buf, error_buf_size))) {
+                return false;
+            }
+
             /* store to module tag declarations */
-            module->tags[tag_index].attribute = tag_attribute;
-            module->tags[tag_index].type = tag_type;
+            tag->attribute = tag_attribute;
+            tag->type = tag_type;
+            tag->tag_type = func_type;
         }
     }
 
@@ -7754,15 +7808,24 @@ re_scan:
 
                 /* check validity of tag_index against module->tag_count */
                 /* check tag index is within the tag index space */
-                if (tag_index >= module->tag_count) {
+                if (tag_index >= module->import_tag_count + module->tag_count) {
                     set_error_buf(error_buf, error_buf_size,
                                   "unknown tag index");
                     goto fail;
                 }
 
-                /* the index of the type stored in the tag declaration */
-                uint8 tag_type_index = module->tags[tag_index].type;
-
+                /* the tag_type is stored in either the WASMTag (section tags)
+                 * or WASMTagImport (import tag) */
+                WASMType *func_type = NULL;
+                if (tag_index < module->import_tag_count) {
+                    func_type = module->import_tags[tag_index].u.tag.tag_type;
+                }
+                else {
+                    func_type =
+                        module->tags[tag_index - module->import_tag_count]
+                            ->tag_type;
+                }
+#if 0
                 /* check validity of tag_type_index */
                 if (tag_type_index >= module->type_count) {
                     set_error_buf(error_buf, error_buf_size,
@@ -7772,6 +7835,7 @@ re_scan:
 
                 /* check, that the type of the referred tag returns void */
                 WASMType *func_type = (WASMType *)module->types[tag_type_index];
+#endif
                 if (func_type->result_count != 0) {
                     set_error_buf(error_buf, error_buf_size,
                                   "tag type signature does not return void");
@@ -7840,13 +7904,27 @@ re_scan:
 
                 /* check validity of tag_index against module->tag_count */
                 /* check tag index is within the tag index space */
-                if (tag_index >= module->tag_count) {
+                if (tag_index >= module->import_tag_count + module->tag_count) {
+                    LOG_VERBOSE("In %s, unknown tag at WASM_OP_CATCH\n",
+                                __FUNCTION__);
                     set_error_buf(error_buf, error_buf_size, "unknown tag");
                     goto fail;
                 }
 
+                /* the tag_type is stored in either the WASMTag (section tags)
+                 * or WASMTagImport (import tag) */
+                WASMType *func_type = NULL;
+                if (tag_index < module->import_tag_count) {
+                    func_type = module->import_tags[tag_index].u.tag.tag_type;
+                }
+                else {
+                    func_type =
+                        module->tags[tag_index - module->import_tag_count]
+                            ->tag_type;
+                }
+#if 0
                 /* the index of the type stored in the tag declaration */
-                uint8 tag_type_index = module->tags[tag_index].type;
+                uint8 tag_type_index = module->tags[tag_index]->type;
 
                 /* check validity of tag_type_index */
                 if (tag_type_index >= module->type_count) {
@@ -7857,6 +7935,7 @@ re_scan:
 
                 /* check, that the type of the referred tag returns void */
                 WASMType *func_type = module->types[tag_type_index];
+#endif
                 if (func_type->result_count != 0) {
                     set_error_buf(error_buf, error_buf_size,
                                   "tag type signature does not return void");
@@ -7874,7 +7953,10 @@ re_scan:
 
                 BlockType new_block_type;
                 new_block_type.is_value_type = false;
+#if 0
                 new_block_type.u.type = module->types[tag_type_index];
+#endif
+                new_block_type.u.type = func_type;
 
                 /*
                  * replace frame_csp by LABEL_TYPE_CATCH

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -697,7 +697,6 @@ wasm_loader_find_export(const WASMModule *module, const char *module_name,
     WASMExport *export =
         loader_find_export((WASMModuleCommon *)module, module_name, field_name,
                            export_kind, error_buf, error_buf_size);
-    ;
     return export;
 }
 #endif

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -7755,20 +7755,7 @@ re_scan:
                         module->tags[tag_index - module->import_tag_count]
                             ->tag_type;
                 }
-#if 0
-                /* the index of the type stored in the tag declaration */
-                uint8 tag_type_index = module->tags[tag_index]->type;
 
-                /* check validity of tag_type_index */
-                if (tag_type_index >= module->type_count) {
-                    set_error_buf(error_buf, error_buf_size,
-                                  "unknown tag type index");
-                    goto fail;
-                }
-
-                /* check, that the type of the referred tag returns void */
-                WASMType *func_type = module->types[tag_type_index];
-#endif
                 if (func_type->result_count != 0) {
                     set_error_buf(error_buf, error_buf_size,
                                   "tag type signature does not return void");
@@ -7786,9 +7773,6 @@ re_scan:
 
                 BlockType new_block_type;
                 new_block_type.is_value_type = false;
-#if 0
-                new_block_type.u.type = module->types[tag_type_index];
-#endif
                 new_block_type.u.type = func_type;
 
                 /*

--- a/core/iwasm/interpreter/wasm_loader.c
+++ b/core/iwasm/interpreter/wasm_loader.c
@@ -7140,11 +7140,26 @@ check_block_stack(WASMLoaderContext *loader_ctx, BranchBlock *block,
         return true;
     }
 
-    /* Check stack cell num equals return cell num */
     if (available_stack_cell != return_cell_num) {
+#if WASM_ENABLE_EXCE_HANDLING != 0
+        /* testspec: this error message format is expected by try_catch.wast */
+        snprintf(
+            error_buf, error_buf_size, "type mismatch: %s requires [%s]%s[%s]",
+            block->label_type == LABEL_TYPE_TRY
+                    || (block->label_type == LABEL_TYPE_CATCH
+                        && return_cell_num > 0)
+                ? "instruction"
+                : "block",
+            return_cell_num > 0 ? type2str(return_types[0]) : "",
+            " but stack has ",
+            available_stack_cell > 0 ? type2str(*(loader_ctx->frame_ref - 1))
+                                     : "");
+        goto fail;
+#else
         set_error_buf(error_buf, error_buf_size,
                       "type mismatch: stack size does not match block type");
         goto fail;
+#endif
     }
 
     /* Check stack values match return types */
@@ -7626,8 +7641,8 @@ re_scan:
                 /* check validity of tag_index against module->tag_count */
                 /* check tag index is within the tag index space */
                 if (tag_index >= module->import_tag_count + module->tag_count) {
-                    snprintf(error_buf, error_buf_size, 
-                        "unknown tag %d", tag_index);
+                    snprintf(error_buf, error_buf_size, "unknown tag %d",
+                             tag_index);
                     goto fail;
                 }
 
@@ -7642,44 +7657,40 @@ re_scan:
                         module->tags[tag_index - module->import_tag_count]
                             ->tag_type;
                 }
-#if 0
-                /* check validity of tag_type_index */
-                if (tag_type_index >= module->type_count) {
-                    set_error_buf(error_buf, error_buf_size,
-                                  "unknown tag type index");
-                    goto fail;
-                }
 
-                /* check, that the type of the referred tag returns void */
-                WASMType *func_type = (WASMType *)module->types[tag_type_index];
-#endif
                 if (func_type->result_count != 0) {
                     set_error_buf(error_buf, error_buf_size,
                                   "tag type signature does not return void");
                     goto fail;
                 }
 
-                /* Check stack cell num equals tag param num */
-                int32 available_stack_cell = 
-                    (int32)(loader_ctx->stack_cell_num - cur_block->stack_cell_num);
-                if (available_stack_cell < func_type->param_count) {
-                    set_error_buf(error_buf, error_buf_size,
-                                "type mismatch: stack size does not match tag type");
-                    goto fail;
-                }
+                int32 available_stack_cell =
+                    (int32)(loader_ctx->stack_cell_num
+                            - cur_block->stack_cell_num);
 
-                /* Check stack values match return types by comparing tag param types with stack cells */
+                /* Check stack values match return types by comparing tag param
+                 * types with stack cells */
                 uint8 *frame_ref = loader_ctx->frame_ref;
-                for (int tti = (int32)func_type->param_count - 1; tti >= 0; tti--) {
+                for (int tti = (int32)func_type->param_count - 1; tti >= 0;
+                     tti--) {
                     if (!check_stack_top_values(frame_ref, available_stack_cell,
-                            func_type->types[tti], error_buf, error_buf_size)) 
-                    {
-                        set_error_buf(error_buf, error_buf_size,
-                                    "type mismatch: stack size does not match tag type");
+                                                func_type->types[tti],
+                                                error_buf, error_buf_size)) {
+                        snprintf(error_buf, error_buf_size,
+                                 "type mismatch: instruction requires [%s] but "
+                                 "stack has [%s]",
+                                 func_type->param_count > 0
+                                     ? type2str(func_type->types[tti])
+                                     : "",
+                                 available_stack_cell > 0
+                                     ? type2str(*(loader_ctx->frame_ref - 1))
+                                     : "");
                         goto fail;
                     }
-                    frame_ref -= wasm_value_type_cell_num(func_type->types[tti]);
-                    available_stack_cell -= wasm_value_type_cell_num(func_type->types[tti]);
+                    frame_ref -=
+                        wasm_value_type_cell_num(func_type->types[tti]);
+                    available_stack_cell -=
+                        wasm_value_type_cell_num(func_type->types[tti]);
                 }
 
                 /* throw is stack polymorphic */

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -1882,7 +1882,9 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
     module_inst->table_count = module->import_table_count + module->table_count;
     module_inst->e->function_count =
         module->import_function_count + module->function_count;
+#if WASM_ENABLE_TAGS != 0
     module_inst->tag_count = module->import_tag_count + module->tag_count;
+#endif
 
     /* export */
     module_inst->export_func_count = get_export_count(module, EXPORT_KIND_FUNC);

--- a/core/iwasm/interpreter/wasm_runtime.c
+++ b/core/iwasm/interpreter/wasm_runtime.c
@@ -726,6 +726,94 @@ functions_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
     return functions;
 }
 
+#if WASM_ENABLE_TAGS != 0
+/**
+ * Destroy tags instances.
+ */
+static void
+tags_deinstantiate(WASMTagInstance *tags, void **import_tag_ptrs)
+{
+    if (tags) {
+        wasm_runtime_free(tags);
+    }
+    if (import_tag_ptrs) {
+        wasm_runtime_free(import_tag_ptrs);
+    }
+}
+
+/**
+ * Instantiate tags in a module.
+ */
+static WASMTagInstance *
+tags_instantiate(const WASMModule *module, WASMModuleInstance *module_inst,
+                 char *error_buf, uint32 error_buf_size)
+{
+    WASMImport *import;
+    uint32 i, tag_count = module->import_tag_count + module->tag_count;
+    uint64 total_size = sizeof(WASMTagInstance) * (uint64)tag_count;
+    WASMTagInstance *tags, *tag;
+
+    if (!(tags = runtime_malloc(total_size, error_buf, error_buf_size))) {
+        return NULL;
+    }
+
+    total_size = sizeof(void *) * (uint64)module->import_tag_count;
+    if (total_size > 0
+        && !(module_inst->import_tag_ptrs =
+                 runtime_malloc(total_size, error_buf, error_buf_size))) {
+        wasm_runtime_free(tags);
+        return NULL;
+    }
+
+    /* instantiate tags from import section */
+    tag = tags;
+    import = module->import_tags;
+    for (i = 0; i < module->import_tag_count; i++, import++) {
+        tag->is_import_tag = true;
+
+#if WASM_ENABLE_MULTI_MODULE != 0
+        if (import->u.tag.import_module) {
+            if (!(tag->import_module_inst = get_sub_module_inst(
+                      module_inst, import->u.tag.import_module))) {
+                set_error_buf(error_buf, error_buf_size, "unknown tag");
+                goto fail;
+            }
+
+            if (!(tag->import_tag_inst =
+                      wasm_lookup_tag(tag->import_module_inst,
+                                      import->u.tag.field_name, NULL))) {
+                set_error_buf(error_buf, error_buf_size, "unknown tag");
+                goto fail;
+            }
+        }
+#endif /* WASM_ENABLE_MULTI_MODULE */
+        tag->type = import->u.tag.type;
+        tag->u.tag_import = &import->u.tag;
+        /* Copy the tag pointer to current instance */
+        module_inst->import_tag_ptrs[i] = tag->u.tag_import->import_tag_linked;
+        tag++;
+    }
+
+    /* instantiate tags from tag section */
+    for (i = 0; i < module->tag_count; i++) {
+        tag->is_import_tag = false;
+        tag->type = module->tags[i]->type;
+        tag->u.tag = module->tags[i];
+
+#if WASM_ENABLE_FAST_INTERP != 0
+        /* tag->const_cell_num = function->u.func->const_cell_num; */
+#endif
+        tag++;
+    }
+    bh_assert((uint32)(tag - tags) == tag_count);
+
+    return tags;
+fail:
+    wasm_runtime_free(tags);
+    return NULL;
+}
+#endif
+
 /**
  * Destroy global instances.
  */
@@ -924,6 +1012,52 @@ export_functions_instantiate(const WASMModule *module,
     bh_assert((uint32)(export_func - export_funcs) == export_func_count);
     return export_funcs;
 }
+
+#if WASM_ENABLE_TAGS != 0
+/**
+ * Destroy export function instances.
+ */
+static void
+export_tags_deinstantiate(WASMExportTagInstance *tags)
+{
+    if (tags)
+        wasm_runtime_free(tags);
+}
+
+/**
+ * Instantiate export functions in a module.
+ */
+static WASMExportTagInstance *
+export_tags_instantiate(const WASMModule *module,
+                        WASMModuleInstance *module_inst,
+                        uint32 export_tag_count, char *error_buf,
+                        uint32 error_buf_size)
+{
+    WASMExportTagInstance *export_tags, *export_tag;
+    WASMExport *export = module->exports;
+    uint32 i;
+    uint64 total_size =
+        sizeof(WASMExportTagInstance) * (uint64)export_tag_count;
+
+    if (!(export_tag = export_tags =
+              runtime_malloc(total_size, error_buf, error_buf_size))) {
+        return NULL;
+    }
+
+    for (i = 0; i < module->export_count; i++, export ++)
+        if (export->kind == EXPORT_KIND_TAG) {
+            export_tag->name = export->name;
+
+            bh_assert((uint32)(module_inst->export_tags));
+
+            export_tag->tag = &module_inst->tags[export->index];
+            export_tag++;
+        }
+
+    bh_assert((uint32)(export_tag - export_tags) == export_tag_count);
+    return export_tags;
+}
+#endif
 
 #if WASM_ENABLE_MULTI_MODULE != 0
 static void
@@ -1748,6 +1882,7 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
     module_inst->table_count = module->import_table_count + module->table_count;
     module_inst->e->function_count =
         module->import_function_count + module->function_count;
+    module_inst->tag_count = module->import_tag_count + module->tag_count;
 
     /* export */
     module_inst->export_func_count = get_export_count(module, EXPORT_KIND_FUNC);
@@ -1756,11 +1891,14 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
         get_export_count(module, EXPORT_KIND_TABLE);
     module_inst->export_memory_count =
         get_export_count(module, EXPORT_KIND_MEMORY);
+#if WASM_ENABLE_TAGS != 0
+    module_inst->export_tag_count = get_export_count(module, EXPORT_KIND_TAG);
+#endif
     module_inst->export_global_count =
         get_export_count(module, EXPORT_KIND_GLOBAL);
 #endif
 
-    /* Instantiate memories/tables/functions */
+    /* Instantiate memories/tables/functions/tags */
     if ((module_inst->memory_count > 0
          && !(module_inst->memories =
                   memories_instantiate(module, module_inst, parent, heap_size,
@@ -1777,6 +1915,15 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
                      module, module_inst, module_inst->export_func_count,
                      error_buf, error_buf_size)))
 #if WASM_ENABLE_MULTI_MODULE != 0
+#if WASM_ENABLE_TAGS != 0
+        || (module_inst->tag_count > 0
+            && !(module_inst->tags = tags_instantiate(
+                     module, module_inst, error_buf, error_buf_size)))
+        || (module_inst->export_tag_count > 0
+            && !(module_inst->export_tags = export_tags_instantiate(
+                     module, module_inst, module_inst->export_tag_count,
+                     error_buf, error_buf_size)))
+#endif
         || (module_inst->export_global_count > 0
             && !(module_inst->export_globals = export_globals_instantiate(
                      module, module_inst, module_inst->export_global_count,
@@ -1793,7 +1940,6 @@ wasm_instantiate(WASMModule *module, WASMModuleInstance *parent,
     ) {
         goto fail;
     }
-
     if (global_count > 0) {
         /* Initialize the global data */
         global_data = module_inst->global_data;
@@ -2211,8 +2357,16 @@ wasm_deinstantiate(WASMModuleInstance *module_inst, bool is_sub_inst)
     tables_deinstantiate(module_inst);
     functions_deinstantiate(module_inst->e->functions,
                             module_inst->e->function_count);
+#if WASM_ENABLE_TAGS != 0
+    tags_deinstantiate(module_inst->tags, module_inst->import_tag_ptrs);
+#endif
+
     globals_deinstantiate(module_inst->e->globals);
     export_functions_deinstantiate(module_inst->export_functions);
+#if WASM_ENABLE_TAGS != 0
+    export_tags_deinstantiate(module_inst->export_tags);
+#endif
+
 #if WASM_ENABLE_MULTI_MODULE != 0
     export_globals_deinstantiate(module_inst->export_globals);
 #endif
@@ -2286,6 +2440,21 @@ wasm_lookup_table(const WASMModuleInstance *module_inst, const char *name)
     (void)module_inst->export_tables;
     return module_inst->tables[0];
 }
+
+#if WASM_ENABLE_TAGS != 0
+WASMTagInstance *
+wasm_lookup_tag(const WASMModuleInstance *module_inst, const char *name,
+                const char *signature)
+{
+    uint32 i;
+    for (i = 0; i < module_inst->export_tag_count; i++)
+        if (!strcmp(module_inst->export_tags[i].name, name))
+            return module_inst->export_tags[i].tag;
+    (void)signature;
+    return NULL;
+}
+#endif
+
 #endif
 
 #ifdef OS_ENABLE_HW_BOUND_CHECK

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -370,9 +370,10 @@ struct WASMModuleInstance {
     /* WASM/AOT module extra info, for AOTModuleInstance,
        it denotes `AOTModuleInstanceExtra *` */
     DefPointer(WASMModuleInstanceExtra *, e);
+#if WASM_ENABLE_TAGS != 0
     /* Array of tag pointers */
     DefPointer(void **, import_tag_ptrs);
-
+#endif
     /* Default WASM operand stack size */
     uint32 default_wasm_stack_size;
     uint32 reserved[3];

--- a/core/iwasm/interpreter/wasm_runtime.h
+++ b/core/iwasm/interpreter/wasm_runtime.h
@@ -27,6 +27,9 @@ typedef struct WASMFunctionInstance WASMFunctionInstance;
 typedef struct WASMMemoryInstance WASMMemoryInstance;
 typedef struct WASMTableInstance WASMTableInstance;
 typedef struct WASMGlobalInstance WASMGlobalInstance;
+#if WASM_ENABLE_TAGS != 0
+typedef struct WASMTagInstance WASMTagInstance;
+#endif
 
 /**
  * When LLVM JIT, WAMR compiler or AOT is enabled, we should ensure that
@@ -180,6 +183,30 @@ struct WASMFunctionInstance {
 #endif
 };
 
+#if WASM_ENABLE_TAGS != 0
+struct WASMTagInstance {
+    bool is_import_tag;
+    /* tag attribute */
+    uint8 attribute;
+    /* tag type index */
+    uint32 type;
+    union {
+        WASMTagImport *tag_import;
+        WASMTag *tag;
+    } u;
+
+#if WASM_ENABLE_MULTI_MODULE != 0
+    WASMModuleInstance *import_module_inst;
+    WASMTagInstance *import_tag_inst;
+#endif
+};
+#endif
+
+#if WASM_ENABLE_EXCE_HANDLING != 0
+#define INVALID_TAGINDEX ((uint32)0xFFFFFFFF)
+#define SET_INVALID_TAGINDEX(tag) (tag = INVALID_TAGINDEX)
+#define IS_INVALID_TAGINDEX(tag) ((tag & INVALID_TAGINDEX) == INVALID_TAGINDEX)
+#endif
 typedef struct WASMExportFuncInstance {
     char *name;
     WASMFunctionInstance *function;
@@ -199,6 +226,13 @@ typedef struct WASMExportMemInstance {
     char *name;
     WASMMemoryInstance *memory;
 } WASMExportMemInstance;
+
+#if WASM_ENABLE_TAGS != 0
+typedef struct WASMExportTagInstance {
+    char *name;
+    WASMTagInstance *tag;
+} WASMExportTagInstance;
+#endif
 
 /* wasm-c-api import function info */
 typedef struct CApiFuncImport {
@@ -273,6 +307,9 @@ struct WASMModuleInstance {
     /* global and table info */
     uint32 global_data_size;
     uint32 table_count;
+#if WASM_ENABLE_TAGS != 0
+    uint32 tag_count;
+#endif
     DefPointer(uint8 *, global_data);
     /* For AOTModuleInstance, it denotes `AOTTableInstance *` */
     DefPointer(WASMTableInstance **, tables);
@@ -283,13 +320,23 @@ struct WASMModuleInstance {
     /* function type indexes */
     DefPointer(uint32 *, func_type_indexes);
 
+#if WASM_ENABLE_TAGS != 0
+    DefPointer(WASMTagInstance *, tags);
+#endif
     uint32 export_func_count;
     uint32 export_global_count;
     uint32 export_memory_count;
     uint32 export_table_count;
+#if WASM_ENABLE_TAGS != 0
+    uint32 export_tag_count;
+#endif
+
     /* For AOTModuleInstance, it denotes `AOTFunctionInstance *` */
     DefPointer(WASMExportFuncInstance *, export_functions);
     DefPointer(WASMExportGlobInstance *, export_globals);
+#if WASM_ENABLE_TAGS != 0
+    DefPointer(WASMExportTagInstance *, export_tags);
+#endif
     DefPointer(WASMExportMemInstance *, export_memories);
     DefPointer(WASMExportTabInstance *, export_tables);
 
@@ -323,6 +370,8 @@ struct WASMModuleInstance {
     /* WASM/AOT module extra info, for AOTModuleInstance,
        it denotes `AOTModuleInstanceExtra *` */
     DefPointer(WASMModuleInstanceExtra *, e);
+    /* Array of tag pointers */
+    DefPointer(void **, import_tag_ptrs);
 
     /* Default WASM operand stack size */
     uint32 default_wasm_stack_size;
@@ -433,6 +482,13 @@ wasm_lookup_memory(const WASMModuleInstance *module_inst, const char *name);
 
 WASMTableInstance *
 wasm_lookup_table(const WASMModuleInstance *module_inst, const char *name);
+
+#if WASM_ENABLE_TAGS != 0
+WASMTagInstance *
+wasm_lookup_tag(const WASMModuleInstance *module_inst, const char *name,
+                const char *signature);
+#endif
+
 #endif
 
 bool

--- a/tests/wamr-test-suites/spec-test-script/all.py
+++ b/tests/wamr-test-suites/spec-test-script/all.py
@@ -71,7 +71,7 @@ def ignore_the_case(
     eh_flag=False,
 ):
     # print(f"case_name {case_name}\n")
-    if eh_flag and case_name in [ "tag", "try_catch", "rethrow", "try_delegate" ]:
+    if eh_flag and case_name in [ "throw", "tag", "try_catch", "rethrow", "try_delegate" ]:
         return False
     else:
         return True

--- a/tests/wamr-test-suites/spec-test-script/exception_handling.patch
+++ b/tests/wamr-test-suites/spec-test-script/exception_handling.patch
@@ -1,0 +1,38 @@
+diff --git a/test/core/throw.wast b/test/core/throw.wast
+index d53b5b55..57a0dbca 100644
+--- a/test/core/throw.wast
++++ b/test/core/throw.wast
+@@ -46,6 +46,6 @@
+ 
+ (assert_invalid (module (func (throw 0))) "unknown tag 0")
+ (assert_invalid (module (tag (param i32)) (func (throw 0)))
+-                "type mismatch: instruction requires [i32] but stack has []")
++                "type mismatch: stack size does not match tag type")
+ (assert_invalid (module (tag (param i32)) (func (i64.const 5) (throw 0)))
+-                "type mismatch: instruction requires [i32] but stack has [i64]")
++                "type mismatch: stack size does not match tag type")
+diff --git a/test/core/try_catch.wast b/test/core/try_catch.wast
+index 2a0e9ff6..b7f89f15 100644
+--- a/test/core/try_catch.wast
++++ b/test/core/try_catch.wast
+@@ -251,15 +251,15 @@
+ )
+ 
+ (assert_invalid (module (func (result i32) (try (result i32) (do))))
+-                "type mismatch: instruction requires [i32] but stack has []")
++                "type mismatch: stack size does not match block type")
+ (assert_invalid (module (func (result i32) (try (result i32) (do (i64.const 42)))))
+-                "type mismatch: instruction requires [i32] but stack has [i64]")
++                "type mismatch: stack size does not match block type")
+ (assert_invalid (module (tag) (func (try (do) (catch 0 (i32.const 42)))))
+-                "type mismatch: block requires [] but stack has [i32]")
++                "type mismatch: stack size does not match block type")
+ (assert_invalid (module
+                   (tag (param i64))
+                   (func (result i32)
+                     (try (result i32) (do (i32.const 42)) (catch 0))))
+-                "type mismatch: instruction requires [i32] but stack has [i64]")
++                "type mismatch: stack size does not match block type")
+ (assert_invalid (module (func (try (do) (catch_all (i32.const 42)))))
+-                "type mismatch: block requires [] but stack has [i32]")
++                "type mismatch: stack size does not match block type")

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -523,8 +523,7 @@ function exception_test()
     pushd exception-handling
 
     # restore and clean everything
-    git reset --hard 51c721661b671bb7dc4b3a3acb9e079b49778d36
-    git apply ../../spec-test-script/exception_handling.patch
+    git reset --hard HEAD
 
     popd
     echo $(pwd)
@@ -906,7 +905,7 @@ function trigger()
     if [[ ${ENABLE_EH} == 1 ]]; then
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_EXCE_HANDLING=1"
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_TAIL_CALL=1"
-	    EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_MULTI_MODULE=1"
+        EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_MULTI_MODULE=1"
     fi
     echo "SANITIZER IS" $WAMR_BUILD_SANITIZER
 

--- a/tests/wamr-test-suites/test_wamr.sh
+++ b/tests/wamr-test-suites/test_wamr.sh
@@ -14,7 +14,7 @@ function help()
 {
     echo "test_wamr.sh [options]"
     echo "-c clean previous test results, not start test"
-    echo "-s {suite_name} test only one suite (spec|wasi_certification|wamr_compiler)"
+    echo "-s {suite_name} test only one suite (spec|wasi_certification|wamr_compiler|exception)"
     echo "-m set compile target of iwasm(x86_64|x86_32|armv7_vfp|thumbv7_vfp|riscv64_lp64d|riscv64_lp64|aarch64)"
     echo "-t set compile type of iwasm(classic-interp|fast-interp|jit|aot|fast-jit|multi-tier-jit)"
     echo "-M enable multi module feature"
@@ -523,7 +523,8 @@ function exception_test()
     pushd exception-handling
 
     # restore and clean everything
-    git reset --hard HEAD
+    git reset --hard 51c721661b671bb7dc4b3a3acb9e079b49778d36
+    git apply ../../spec-test-script/exception_handling.patch
 
     popd
     echo $(pwd)
@@ -574,6 +575,13 @@ function exception_test()
     ln -sf ${WORK_DIR}/../spec-test-script/runtest.py .
 
     local ARGS_FOR_SPEC_TEST="-e --no_clean_up "
+
+    # propagate multimodule if set
+    if [[ 1 == ${ENABLE_MULTI_MODULE} ]]; then
+        if [[ $1 == 'classic-interp' || $1 == 'fast-interp' ]]; then
+            ARGS_FOR_SPEC_TEST+="-M "
+        fi
+    fi
 
     # set log directory
     ARGS_FOR_SPEC_TEST+="--log ${REPORT_DIR}"
@@ -898,7 +906,7 @@ function trigger()
     if [[ ${ENABLE_EH} == 1 ]]; then
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_EXCE_HANDLING=1"
         EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_TAIL_CALL=1"
-	EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_MULTI_MODULE=1"
+	    EXTRA_COMPILE_FLAGS+=" -DWAMR_BUILD_MULTI_MODULE=1"
     fi
     echo "SANITIZER IS" $WAMR_BUILD_SANITIZER
 


### PR DESCRIPTION
This PR is the second PR to support exception handling. This includes the following updates:
* Inside the classic interpreter only:
  * Bug fixes and naming convention improvements
  * Additional CI /CD changes to validate ENABLE_EXCE_HANDLING switch builds
    OK on all platforms
  * Import and Export of Exceptions and Tags
